### PR TITLE
handle nonenglish datetimes

### DIFF
--- a/app/models/concerto_template_scheduling/schedule.rb
+++ b/app/models/concerto_template_scheduling/schedule.rb
@@ -104,23 +104,27 @@ module ConcertoTemplateScheduling
     # Otherwise, just set it like normal.  This is a bit confusing due to the differences in how Ruby handles
     # times between 1.9.x and 1.8.x.
     def start_time=(_start_time)
-      if _start_time.kind_of?(Hash)
-        # convert to time, strip off the timezone offset so it reflects local time
-        t = DateTime.strptime("#{_start_time[:date]} #{_start_time[:time]}".gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm"), "#{I18n.t('time.formats.date_long_year')} %I:%M %P")
-        write_attribute(:start_time, Time.zone.parse(Time.iso8601(t.to_s).to_s(:db)))
-      else
-        write_attribute(:start_time, _start_time)
+      Time.use_zone(screen.time_zone) do
+        if _start_time.kind_of?(Hash)
+          # convert to time, strip off the timezone offset so it reflects local time
+          t = DateTime.strptime("#{_start_time[:date]} #{_start_time[:time]}".gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm"), "#{I18n.t('time.formats.date_long_year')} %I:%M %P")
+          write_attribute(:start_time, Time.zone.parse(Time.iso8601(t.to_s).to_s(:db)))
+        else
+          write_attribute(:start_time, _start_time)
+        end
       end
     end
 
     # See start_time=.
     def end_time=(_end_time)
-      if _end_time.kind_of?(Hash)
-        # convert to time, strip off the timezone offset so it reflects local time
-        t = DateTime.strptime("#{_end_time[:date]} #{_end_time[:time]}".gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm"), "#{I18n.t('time.formats.date_long_year')} %I:%M %P")
-        write_attribute(:end_time, Time.zone.parse(Time.iso8601(t.to_s).to_s(:db)))
-      else
-        write_attribute(:end_time, _end_time)
+      Time.use_zone(screen.time_zone) do
+        if _end_time.kind_of?(Hash)
+          # convert to time, strip off the timezone offset so it reflects local time
+          t = DateTime.strptime("#{_end_time[:date]} #{_end_time[:time]}".gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm"), "#{I18n.t('time.formats.date_long_year')} %I:%M %P")
+          write_attribute(:end_time, Time.zone.parse(Time.iso8601(t.to_s).to_s(:db)))
+        else
+          write_attribute(:end_time, _end_time)
+        end
       end
     end
 

--- a/app/models/concerto_template_scheduling/schedule.rb
+++ b/app/models/concerto_template_scheduling/schedule.rb
@@ -7,11 +7,13 @@ module ConcertoTemplateScheduling
     DISPLAY_AS_SCHEDULED=2
     DISPLAY_CONTENT_EXISTS=3
 
-    DISPLAY_WHEN = {
-      I18n.t('concerto_template_scheduling.never') => DISPLAY_NEVER, 
-      I18n.t('concerto_template_scheduling.as_scheduled') => DISPLAY_AS_SCHEDULED,
-      I18n.t('concerto_template_scheduling.content_exists') => DISPLAY_CONTENT_EXISTS
-    }
+    def self.display_when_options
+      {
+        I18n.t('concerto_template_scheduling.never') => DISPLAY_NEVER, 
+        I18n.t('concerto_template_scheduling.as_scheduled') => DISPLAY_AS_SCHEDULED,
+        I18n.t('concerto_template_scheduling.content_exists') => DISPLAY_CONTENT_EXISTS
+      }
+    end
 
     belongs_to :screen
     belongs_to :template
@@ -65,16 +67,16 @@ module ConcertoTemplateScheduling
     def default_config
       {
         'display_when' => DISPLAY_AS_SCHEDULED,
-        'from_time' => '12:00 am',
-        'to_time' => '11:59 pm'
+        'from_time' => ConcertoConfig[:content_default_start_time],
+        'to_time' => ConcertoConfig[:content_default_end_time]
       }
     end
 
     # Create a new configuration hash if one does not already exist.
     # Called during `after_initialize`, where a config may or may not exist.
     def create_config
-      self.start_time ||= Time.zone.parse("12:00 am", Clock.time + ConcertoConfig[:start_date_offset].to_i.days)
-      self.end_time ||= Time.zone.parse("11:59 pm", Clock.time + ConcertoConfig[:start_date_offset].to_i.days + ConcertoConfig[:default_content_run_time].to_i.days)
+      self.start_time ||= Time.zone.parse(ConcertoConfig[:content_default_start_time], Clock.time + ConcertoConfig[:start_date_offset].to_i.days)
+      self.end_time ||= Time.zone.parse(ConcertoConfig[:content_default_end_time], Clock.time + ConcertoConfig[:start_date_offset].to_i.days + ConcertoConfig[:default_content_run_time].to_i.days)
 
       self.config = {} if !self.config
       self.config = default_config().merge(self.config)
@@ -93,6 +95,8 @@ module ConcertoTemplateScheduling
     # Called during `before_validation`.
     def save_config
       self.config['scheduling_criteria'] = '' if self.config['scheduling_criteria'] == 'null'
+      self.config['from_time'] = self.config['from_time'].gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm")
+      self.config['to_time'] = self.config['to_time'].gsub(I18n.t('time.am'), "am").gsub(I18n.t('time.pm'), "pm")
       self.data = JSON.dump(self.config)
     end
 
@@ -132,23 +136,28 @@ module ConcertoTemplateScheduling
       effective = false
 
       # if it is during the valid/active time frame and the template still exists
-Rails.logger.debug("\n\nIS_EFFECTIVE?\n\nClock.time = #{Clock.time}\nself.start_time = #{self.start_time}\n")
-      if Clock.time >= self.start_time && Clock.time <= self.end_time && !self.template.nil?
-        # and it is within the viewing window for the day
-        if Clock.time >= Time.parse(self.config['from_time']) && Clock.time <= Time.parse(self.config['to_time'])
-          # and it is either marked as always shown
-          if self.config['display_when'].to_i == DISPLAY_CONTENT_EXISTS
-            # or if we detect actual content on the specified feed
-            if !self.feed.nil? && !self.feed.approved_contents.active.where('kind_id != 4').empty?
-              effective = true
-            end
-          elsif self.config['display_when'].to_i == DISPLAY_AS_SCHEDULED
-            if !self.config['scheduling_criteria'].empty?
-              s = IceCube::Schedule.new(self.start_time)
-              s.add_recurrence_rule(RecurringSelect.dirty_hash_to_rule(self.config['scheduling_criteria']))
-              effective = s.occurs_on? Clock.time
-            else
-              # no schedule was set
+      # This should consider time from the perspective of the screen's timezone...  so we will use Clock.time.in_time_zone(screen.time_zone) instead,
+      # espcially because the from_time and to_time in the config is stored without regard to timezone (ie: considered in terms of local time for the screen).
+      Time.use_zone(screen.time_zone) do
+        current_time = Clock.time.in_time_zone(screen.time_zone)
+Rails.logger.debug("\n\ntemplate = #{template.name}\ncurrent_time = #{current_time}\nfrom_time = #{Time.zone.parse(self.config['from_time'])}\nself.start_time = #{self.start_time.in_time_zone(screen.time_zone)}\n")
+        if current_time >= self.start_time && current_time <= self.end_time && !self.template.nil?
+          # and it is within the viewing window for the day
+          if current_time >= Time.zone.parse(self.config['from_time']) && current_time <= Time.zone.parse(self.config['to_time'])
+            # and it is either marked as always shown
+            if self.config['display_when'].to_i == DISPLAY_CONTENT_EXISTS
+              # or if we detect actual content on the specified feed
+              if !self.feed.nil? && !self.feed.approved_contents.active.where('kind_id != 4').empty?
+                effective = true
+              end
+            elsif self.config['display_when'].to_i == DISPLAY_AS_SCHEDULED
+              if !self.config['scheduling_criteria'].empty?
+                s = IceCube::Schedule.new(self.start_time)
+                s.add_recurrence_rule(RecurringSelect.dirty_hash_to_rule(self.config['scheduling_criteria']))
+                effective = s.occurs_on? current_time
+              else
+                # no schedule was set
+              end
             end
           end
         end

--- a/app/views/concerto_template_scheduling/schedules/_form.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/_form.html.erb
@@ -18,13 +18,13 @@
               <div class="input">
                 <div class="input-prepend cursor-pointer" style="margin-bottom: 6px;">
                   <span class="add-on"><i class="fa fa-calendar"></i></span>
-                  <%= f.text_field "start_time[date]", :id => "start_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.start_time, format: :date_long_year) %>
+                  <%= f.text_field "start_time[date]", :id => "start_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.start_time.in_time_zone(@schedule.screen.time_zone), format: :date_long_year) %>
                 </div>
                 <p>&nbsp;<a class="event-toggleTimeSelects" href="#"><%= t('.set_specific_times') %></a></p>
                 <div class="event-timeSelectDiv">
                   <div class="input-prepend">
                     <span class="add-on"><%= t(:at) %></span>
-                    <%= f.text_field "start_time[time]", :id => "start_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.start_time, format: :twelve_hour_time) %>
+                    <%= f.text_field "start_time[time]", :id => "start_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.start_time.in_time_zone(@schedule.screen.time_zone), format: :twelve_hour_time) %>
                   </div>
                 </div>
               </div>
@@ -36,12 +36,12 @@
               <div class="input">
                 <div class="input-prepend cursor-pointer" style="margin-bottom: 6px;">
                   <span class="add-on"><i class="fa fa-calendar"></i></span>
-                  <%= f.text_field "end_time[date]", :id => "end_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.end_time, format: :date_long_year) %>
+                  <%= f.text_field "end_time[date]", :id => "end_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.end_time.in_time_zone(@schedule.screen.time_zone), format: :date_long_year) %>
                 </div>
                 <div class="event-timeSelectDiv">
                   <div class="input-prepend">
                     <span class="add-on"><%= t(:at) %></span>
-                    <%= f.text_field "end_time[time]", :id => "end_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.end_time, format: :twelve_hour_time) %>
+                    <%= f.text_field "end_time[time]", :id => "end_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.end_time.in_time_zone(@schedule.screen.time_zone), format: :twelve_hour_time) %>
                   </div>
                 </div>
               </div>

--- a/app/views/concerto_template_scheduling/schedules/_form.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/_form.html.erb
@@ -55,7 +55,7 @@
       <div class="clearfix">
         <%= label_tooltip "schedule", 'config_display_when', ConcertoTemplateScheduling::Schedule.human_attribute_name(:display_when), :tip => t('.display_when_tip') %>
         <div class="input">
-          <%= config.select :display_when, options_for_select(ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN, @schedule.config['display_when']) %>
+          <%= config.select :display_when, options_for_select(ConcertoTemplateScheduling::Schedule.display_when_options, @schedule.config['display_when']) %>
         </div>
       </div>
 
@@ -89,7 +89,7 @@
                 <%= label_tooltip "schedule", :from_time, ConcertoTemplateScheduling::Schedule.human_attribute_name(:from_time), :tip => t('.times_tip') %>
                 <div class="input-prepend">
                   <span class="add-on"><%= t(:at) %></span>
-                  <%= config.text_field(:from_time, :maxlength => 20, :class => "timefield input-small", :value => @schedule.config['from_time']) %>
+                  <%= config.text_field(:from_time, :maxlength => 20, :class => "timefield input-small", :value => l(DateTime.strptime(@schedule.config['from_time'], '%I:%M %P'), format: :twelve_hour_time)) %>
                 </div>
               </div>
             </div>
@@ -98,7 +98,7 @@
                 <%= f.label :to_time %>
                 <div class="input-prepend">
                   <span class="add-on"><%= t(:at) %></span>
-                  <%= config.text_field(:to_time, :maxlength => 20, :class => "timefield input-small", :value => @schedule.config['to_time']) %>
+                  <%= config.text_field(:to_time, :maxlength => 20, :class => "timefield input-small", :value => l(DateTime.strptime(@schedule.config['to_time'], '%I:%M %P'), format: :twelve_hour_time)) %>
                 </div>
               </div>
             </div>

--- a/app/views/concerto_template_scheduling/schedules/_form.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/_form.html.erb
@@ -17,14 +17,14 @@
               <%= label_tooltip "schedule", :start_time, t('.valid_from'), :tip => t('.valid_tip') %>
               <div class="input">
                 <div class="input-prepend cursor-pointer" style="margin-bottom: 6px;">
-                  <span class="add-on"><i class="icon-calendar"></i></span>
-                  <%= f.text_field("start_time[date]", :id => "start_time_date", :maxlength => 20, :class => "datefield input-small", :value => @schedule.start_time.strftime("%m/%d/%Y")) %>
+                  <span class="add-on"><i class="fa fa-calendar"></i></span>
+                  <%= f.text_field "start_time[date]", :id => "start_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.start_time, format: :date_long_year) %>
                 </div>
                 <p>&nbsp;<a class="event-toggleTimeSelects" href="#"><%= t('.set_specific_times') %></a></p>
                 <div class="event-timeSelectDiv">
                   <div class="input-prepend">
                     <span class="add-on"><%= t(:at) %></span>
-                    <%= f.text_field("start_time[time]", :id => "start_time_time", :maxlength => 20, :class => "timefield input-small", :value => @schedule.start_time.strftime("%l:%M%P")) %>
+                    <%= f.text_field "start_time[time]", :id => "start_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.start_time, format: :twelve_hour_time) %>
                   </div>
                 </div>
               </div>
@@ -35,13 +35,13 @@
               <%= f.label :end_time, t('.valid_until') %>
               <div class="input">
                 <div class="input-prepend cursor-pointer" style="margin-bottom: 6px;">
-                  <span class="add-on"><i class="icon-calendar"></i></span>
-                  <%= f.text_field("end_time[date]", :id => "end_time_date", :maxlength => 20, :class => "datefield input-small", :value => @schedule.end_time.strftime("%m/%d/%Y")) %>
+                  <span class="add-on"><i class="fa fa-calendar"></i></span>
+                  <%= f.text_field "end_time[date]", :id => "end_time_date", :maxlength => 20, :class => "datefield input-small", :value => l(@schedule.end_time, format: :date_long_year) %>
                 </div>
                 <div class="event-timeSelectDiv">
                   <div class="input-prepend">
                     <span class="add-on"><%= t(:at) %></span>
-                    <%= f.text_field("end_time[time]", :id => "end_time_time", :maxlength => 20, :class => "timefield input-small", :value => @schedule.end_time.strftime("%l:%M%P")) %>
+                    <%= f.text_field "end_time[time]", :id => "end_time_time", :maxlength => 20, :class => "timefield input-small", :value => l(@schedule.end_time, format: :twelve_hour_time) %>
                   </div>
                 </div>
               </div>

--- a/app/views/concerto_template_scheduling/schedules/index.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/index.html.erb
@@ -34,8 +34,8 @@
               <%= image_tag main_app.preview_template_path(schedule.template, :height => 60, :format => :png), :style => "margin: 0px;" %>
             </td>
             <td>
-              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(schedule.start_time, :format => :short_day) %> <%= l(schedule.start_time, :format => :twelve_hour_time) %><br/>
-              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(schedule.end_time, :format => :short_day) %> <%= l(schedule.end_time, :format => :twelve_hour_time) %><br/>
+              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(schedule.start_time.in_time_zone(schedule.screen.time_zone), :format => :short_day) %> <%= l(schedule.start_time.in_time_zone(schedule.screen.time_zone), :format => :twelve_hour_time) %><br/>
+              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(schedule.end_time.in_time_zone(schedule.screen.time_zone), :format => :short_day) %> <%= l(schedule.end_time.in_time_zone(schedule.screen.time_zone), :format => :twelve_hour_time) %><br/>
               <%= t('concerto_template_scheduling.effective') %>: <b><%= schedule.is_effective? ? t(:yes) : t(:no) %></b>
             </td>
             <td>

--- a/app/views/concerto_template_scheduling/schedules/index.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/index.html.erb
@@ -39,7 +39,7 @@
               <%= t('concerto_template_scheduling.effective') %>: <b><%= schedule.is_effective? ? t(:yes) : t(:no) %></b>
             </td>
             <td>
-              <b><%= ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN.key(schedule.config['display_when'].to_i) %></b><br/>
+              <b><%= ConcertoTemplateScheduling::Schedule.display_when_options.key(schedule.config['display_when'].to_i) %></b><br/>
               <% if schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_CONTENT_EXISTS %>
                 <% if can? :read, schedule.feed %>
                   <%= link_to schedule.feed.name, main_app.feed_path(schedule.feed) %><br/>

--- a/app/views/concerto_template_scheduling/schedules/index.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/index.html.erb
@@ -34,8 +34,8 @@
               <%= image_tag main_app.preview_template_path(schedule.template, :height => 60, :format => :png), :style => "margin: 0px;" %>
             </td>
             <td>
-              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(schedule.start_time, :format => :long) %><br/>
-              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(schedule.end_time, :format => :long) %><br/>
+              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(schedule.start_time, :format => :short_day) %> <%= l(schedule.start_time, :format => :twelve_hour_time) %><br/>
+              <%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(schedule.end_time, :format => :short_day) %> <%= l(schedule.end_time, :format => :twelve_hour_time) %><br/>
               <%= t('concerto_template_scheduling.effective') %>: <b><%= schedule.is_effective? ? t(:yes) : t(:no) %></b>
             </td>
             <td>

--- a/app/views/concerto_template_scheduling/schedules/show.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/show.html.erb
@@ -31,8 +31,8 @@
             <div class="default-padding clearfix">
                   <%= image_tag main_app.preview_template_path(@schedule.template, :height => 200, :format => :png), :style => "margin: 0px 1em 0px 0px;" %>
 
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(@schedule.start_time, :format => :short_day) %> <%= l(@schedule.start_time, :format => :twelve_hour_time) %></p>
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(@schedule.end_time, :format => :short_day) %> <%= l(@schedule.end_time, :format => :twelve_hour_time) %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(@schedule.start_time.in_time_zone(@schedule.screen.time_zone), :format => :short_day) %> <%= l(@schedule.start_time.in_time_zone(@schedule.screen.time_zone), :format => :twelve_hour_time) %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(@schedule.end_time.in_time_zone(@schedule.screen.time_zone), :format => :short_day) %> <%= l(@schedule.end_time.in_time_zone(@schedule.screen.time_zone), :format => :twelve_hour_time) %></p>
                   <p><%= t('concerto_template_scheduling.when')%>: <b><%= ConcertoTemplateScheduling::Schedule.display_when_options.key(@schedule.config['display_when'].to_i) %></b></p>
                   <% if @schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_CONTENT_EXISTS %>
                     <% feed = Feed.find(@schedule.config['feed_id'].to_i)

--- a/app/views/concerto_template_scheduling/schedules/show.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/show.html.erb
@@ -31,8 +31,8 @@
             <div class="default-padding clearfix">
                   <%= image_tag main_app.preview_template_path(@schedule.template, :height => 200, :format => :png), :style => "margin: 0px 1em 0px 0px;" %>
 
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(@schedule.start_time, :format => :long) %></p>
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(@schedule.end_time, :format => :long) %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(@schedule.start_time, :format => :short_day) %> <%= l(@schedule.start_time, :format => :twelve_hour_time) %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(@schedule.end_time, :format => :short_day) %> <%= l(@schedule.end_time, :format => :twelve_hour_time) %></p>
                   <p><%= t('concerto_template_scheduling.when')%>: <b><%= ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN.key(@schedule.config['display_when'].to_i) %></b></p>
                   <% if @schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_CONTENT_EXISTS %>
                     <% feed = Feed.find(@schedule.config['feed_id'].to_i)

--- a/app/views/concerto_template_scheduling/schedules/show.html.erb
+++ b/app/views/concerto_template_scheduling/schedules/show.html.erb
@@ -33,7 +33,7 @@
 
                   <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:start_time)%>: <%= l(@schedule.start_time, :format => :short_day) %> <%= l(@schedule.start_time, :format => :twelve_hour_time) %></p>
                   <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:end_time)%>: <%= l(@schedule.end_time, :format => :short_day) %> <%= l(@schedule.end_time, :format => :twelve_hour_time) %></p>
-                  <p><%= t('concerto_template_scheduling.when')%>: <b><%= ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN.key(@schedule.config['display_when'].to_i) %></b></p>
+                  <p><%= t('concerto_template_scheduling.when')%>: <b><%= ConcertoTemplateScheduling::Schedule.display_when_options.key(@schedule.config['display_when'].to_i) %></b></p>
                   <% if @schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_CONTENT_EXISTS %>
                     <% feed = Feed.find(@schedule.config['feed_id'].to_i)
                        feed_name = (feed.blank? ? 'Invalid Feed' : feed.name)
@@ -42,8 +42,8 @@
                   <% elsif @schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_AS_SCHEDULED %>
                     <p><%=@schedule.schedule_in_words %></p>
                   <% end %>
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:from_time)%>: <%= @schedule.config['from_time'] %></p>
-                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:to_time)%>: <%= @schedule.config['to_time'] %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:from_time)%>: <%= l(DateTime.strptime(@schedule.config['from_time'], "%I:%M %P"), format: :twelve_hour_time) %></p>
+                  <p><%= ConcertoTemplateScheduling::Schedule.human_attribute_name(:to_time)%>: <%= l(DateTime.strptime(@schedule.config['to_time'], "%I:%M %P"), format: :twelve_hour_time) %></p>
 
             </div>
           </div>

--- a/app/views/concerto_template_scheduling/screens/_screen_link.html.erb
+++ b/app/views/concerto_template_scheduling/screens/_screen_link.html.erb
@@ -33,7 +33,7 @@
                   <%= image_tag main_app.preview_template_path(schedule.template, :height => 60, :format => :png), :style => "margin: 0px 1em 0px 0px;", :class => 'pull-left' %>
                   <p>
                     <%= link_to(template_scheduling.schedule_path(schedule)) do %>
-                      <%= l(schedule.start_time.to_date, :format => :short) %> - <%= l(schedule.end_time.to_date, :format => :short) %>
+                      <%= l(schedule.start_time, format: :short_day) %> - <%= l(schedule.end_time, format: :short_day) %>
                     <% end %> <b><%= schedule.is_effective? ? t(:active) : '' %></b>
                   </p>
                   <p><b><%= ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN.key(schedule.config['display_when'].to_i) %></b></p>

--- a/app/views/concerto_template_scheduling/screens/_screen_link.html.erb
+++ b/app/views/concerto_template_scheduling/screens/_screen_link.html.erb
@@ -36,7 +36,7 @@
                       <%= l(schedule.start_time, format: :short_day) %> - <%= l(schedule.end_time, format: :short_day) %>
                     <% end %> <b><%= schedule.is_effective? ? t(:active) : '' %></b>
                   </p>
-                  <p><b><%= ConcertoTemplateScheduling::Schedule::DISPLAY_WHEN.key(schedule.config['display_when'].to_i) %></b></p>
+                  <p><b><%= ConcertoTemplateScheduling::Schedule.display_when_options.key(schedule.config['display_when'].to_i) %></b></p>
 
                   <% if schedule.config['display_when'].to_i == ConcertoTemplateScheduling::Schedule::DISPLAY_CONTENT_EXISTS %>
                     <p>
@@ -50,7 +50,7 @@
                     <p><%= schedule.schedule_in_words %></p>
                   <% end %>
                   <% if schedule.config['display_when'].to_i != ConcertoTemplateScheduling::Schedule::DISPLAY_NEVER %>
-                    <p><%= schedule.config['from_time'] %> - <%= schedule.config['to_time'] %></p>
+                    <p><%= l(DateTime.strptime(schedule.config['from_time'], "%I:%M %P"), format: :twelve_hour_time) %> - <%= l(DateTime.strptime(schedule.config['to_time'], "%I:%M %P"), format: :twelve_hour_time) %></p>
                   <% end %>
                 </div>
               </li>

--- a/app/views/public_activity/concerto_template_scheduling/schedule/_create.html.erb
+++ b/app/views/public_activity/concerto_template_scheduling/schedule/_create.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <% if activity.trackable && defined?(template_scheduling) %>
   <%= t('concerto_template_scheduling.starting') %> 
-  <%= link_to l(activity.trackable.start_time.to_date, :format => :short), template_scheduling.schedule_path(activity.trackable) %>
+  <%= link_to l(activity.trackable.start_time, :format => :short_day), template_scheduling.schedule_path(activity.trackable) %>
 <% end %>
   <%= t('concerto_template_scheduling.for') %> 
 <% if Screen.exists?(activity.parameters[:screen_id]) %>

--- a/app/views/public_activity/concerto_template_scheduling/schedule/_update.html.erb
+++ b/app/views/public_activity/concerto_template_scheduling/schedule/_update.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <% if activity.trackable && defined?(template_scheduling) %>
   <%= t('concerto_template_scheduling.starting') %> 
-  <%= link_to l(activity.trackable.start_time.to_date, :format => :short), template_scheduling.schedule_path(activity.trackable) %>
+  <%= link_to l(activity.trackable.start_time, :format => :short_day), template_scheduling.schedule_path(activity.trackable) %>
 <% end %>
   <%= t('concerto_template_scheduling.for') %> 
 <% if Screen.exists?(activity.parameters[:screen_id]) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,74 @@
+de:
+  activerecord:
+    models:
+      concerto_template_scheduling/schedule: 'Schedule'
+    attributes:
+      concerto_template_scheduling/schedule:
+        start_time: 'Active From'
+        end_time: 'Active Until'
+        data: 'Schedule'
+        screen_id: 'Screen'
+        template_id: 'Template'
+        display_when: 'Use Template When'
+        from_time: 'From Time'
+        to_time: 'Until Time'
+        scheduling_criteria: 'Scheduling Criteria'
+
+  concerto_template_scheduling:
+    always: 'Everyday'
+    are_you_sure_delete: 'Are you sure you want to delete the scheduled template %{template} for the %{screen} screen?'
+    as_scheduled: 'As Scheduled'
+    content_exists: 'Content Exists on Feed'
+    effective: 'Currently in Effect? '
+    for: 'for'
+    never: 'Never'
+    from_time_must_precede_to_time: "'From Time' must precede 'To Time'"
+    must_be_selected: 'must be selected'
+    valid: 'Active'
+    when: 'When'
+    schedule_must_be_defined: 'Scheduling Criteria must be defined when "Use Template When" is "As Scheduled"'
+    starting: 'starting'
+
+    schedules:
+      edit:
+        header: 'Edit Template Schedule for %{screen}'
+      form:
+        display_when_tip: 'You can specify that the template will never be used (effectively turning it "off"), will be used every day, will be used on the dates specified by the scheduling criteria, or will be used when content has been detected on a specific feed.'
+        provide_details: 'Provide Details'
+        set_specific_times: 'Set specific times'
+        times_tip: "This is the window during each qualified day that the template will be shown."
+        valid_from: 'Active From'
+        valid_until: 'Active Until'
+        valid_tip: "Active dates determine when a template could be displayed, providing that the 'Use Template When' criteria is met."
+      index:
+        no_templates_scheduled_header: 'No Templates Have Been Scheduled For Any Screens'
+        no_templates_scheduled_msg: "Templates can be scheduled from each screen's detail page."
+      new:
+        header: 'New Template Schedule for %{screen}'
+      show:
+        template_for_screen: '%{template} Template for %{screen} Screen'
+
+    screens:
+      screen_link:
+        add_schedule: 'Add'
+        add_schedule_msg: 'Schedule a template for this screen.'
+        display: 'Display'
+        edit_schedule: 'Edit'
+        footer: 'Scheduled templates will prevail over the default template assigned to the screen.  If multiple scheduled templates are active at the same time one will be arbitrarily chosen.'
+        no_templates_scheduled_header: 'No Templates Scheduled'
+        no_templates_scheduled_msg: 'No templates have been scheduled for this screen.  The template assigned to the screen will be used.'
+        scheduled_templates: 'Scheduled Templates'
+
+    templates:
+      in_use_by:
+        scheduled_for_the_following_screens: 'Scheduled for the following screens'
+
+  public_activity:
+    concerto_template_scheduling:
+      schedule:
+        create:
+          scheduled_template: 'scheduled template '
+        destroy:
+          deleted_a_schedule: 'deleted a scheduled template '
+        update:
+          updated_template: 'updated schedule for template '


### PR DESCRIPTION
This may cause a shift in schedules because it is now considering the times from the perspective of the screen and not the perspective of the user.  So you may need to review your schedules and update them.